### PR TITLE
Bug del botón cancelar arreglado

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1,10 +1,10 @@
 {
   "extName": {
-    "message": "Remember-Tabs - Save & Restore your tabs",
+    "message": "ReTabs - Save & Restore your tabs",
     "description": "Title of the extension"
   },
   "extDescription": {
-    "message": "Remember-Tabs remember your tabs even if you turn off your computer and then you can restore them",
+    "message": "ReTabs remember your tabs even if you turn off your computer and then you can restore them",
     "description": "Description of the extension"
   }
 }

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -1,10 +1,10 @@
 {
   "extName": {
-    "message": "Remember-Tabs - Guarda & Restaura tus ventanas",
+    "message": "ReTabs - Guarda & Restaura tus ventanas",
     "description": "Title of the extension"
   },
   "extDescription": {
-    "message": "Remember-Tabs guarda tus ventanas incluso si apagas la computadora para reabrirlos más tarde",
+    "message": "ReTabs guarda tus ventanas incluso si apagas la computadora para reabrirlos más tarde",
     "description": "Description of the extension"
   }
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "__MSG_extName__",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
   "manifest_version": 3,


### PR DESCRIPTION
Al seleccionar el botón de cancelar, se guardaban las configuraciones que el usuario habia seleccionado en lugar de restablecerlas.